### PR TITLE
A1 square should be dark colored for theme metro and wikipedia

### DIFF
--- a/chessboardjs-themes.js
+++ b/chessboardjs-themes.js
@@ -8,9 +8,9 @@ uscf_piece_theme = function(piece){ return chsspieces["uscf"][piece][0]; };
 wikipedia_piece_theme = function(piece){ return chsspieces["wikipedia"][piece][0]; };
 
 chess24_board_theme = ['#9E7863', '#633526'];
-metro_board_theme = ['#EFEFEF', '#FFFFFF'];
+metro_board_theme = ['#FFFFFF', '#EFEFEF'];
 leipzig_board_theme = ['#FFFFFF', '#E1E1E1'];
-wikipedia_board_theme = ['#D18B47', '#FFCE9E'];
+wikipedia_board_theme = ['#FFCE9E', '#D18B47'];
 dilena_board_theme = ['#FFE5B6', '#B16228'];
 uscf_board_theme = ['#C3C6BE', '#727FA2'];
 symbol_board_theme = ['#FFFFFF', '#58AC8A'];


### PR DESCRIPTION
Thanks for this project !

In a standard chessboard square A1 is dark colored. 

Fixed for metro theme
<img width="546" alt="Screenshot 2025-03-19 at 10 54 52" src="https://github.com/user-attachments/assets/129f8452-8a92-4764-b47c-00c77167114f" />

Fixed for wikipedia theme
<img width="542" alt="Screenshot 2025-03-19 at 10 55 01" src="https://github.com/user-attachments/assets/d4ac0c91-a1dd-4c2f-ac31-7f1f0eefd325" />

